### PR TITLE
Add sampling with alias table

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,30 +20,26 @@ are calibrated for the artificial labels.
 
 ## Example
 
-Since `ConsistencyResampling.jl` extends `Bootstrap.jl`, you have to load both packages.
-
-```julia
-using ConsistencyResampling, Bootstrap
-```
-
 The predictions have to be provided as a matrix of size `(m, n)`, in which each of the `n` columns corresponds to
-one (possibly unnormalized) prediction of the probabilities of the labels `1,…,m`. The corresponding labels
-have to be provided as a vector of length `n`, in which every element is from the set `1,…,m`.
+one normalized prediction of the probabilities of the labels `1,…,m`. The corresponding labels have to be provided
+as a vector of length `n`, in which every element is from the set `1,…,m`.
 
 ```julia
 predictions = rand(10, 500)
+predictions ./= sum(predictions, dims=1)
+
 labels = rand(1:10, 500)
 ```
 
-Consistency resampling is performed similar to the other bootstrapping approaches in `Bootstrap.jl`. However,
-in contrast to the other resampling strategies the statistic has to be a function of both predictions and
-labels. A random number generator can be provided as optional second argument.
+Consistency resampling is performed similar to the other bootstrapping approaches in `Bootstrap.jl`. A random number
+generator can be provided as optional argument.
 
 ```julia
+using ConsistencyResampling
 using Distances
 using Flux: onehotbatch
 
-b = bootstrap(predictions, labels, ConsistentSampling(100_000)) do x, y
+b = bootstrap((predictions, labels), ConsistentSampling(100_000)) do (x, y)
   totalvariation(x, onehotbatch(y, 1:10)) / 500
 end
 ```

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ are calibrated for the artificial labels.
 ## Example
 
 The predictions have to be provided as a matrix of size `(m, n)`, in which each of the `n` columns corresponds to
-one normalized prediction of the probabilities of the labels `1,…,m`. The corresponding labels have to be provided
-as a vector of length `n`, in which every element is from the set `1,…,m`.
+predicted probabilities of the labels `1,…,m`. The corresponding labels have to be provided as a vector of length `n`,
+in which every element is from the set `1,…,m`.
 
 ```julia
 predictions = rand(10, 500)

--- a/src/ConsistencyResampling.jl
+++ b/src/ConsistencyResampling.jl
@@ -6,9 +6,10 @@ using StatsBase
 
 using Random
 
-export ConsistentSampling
+import Bootstrap: bootstrap
 
-include("type.jl")
+export bootstrap, ConsistentSampling
+
 include("bootstrap.jl")
 include("utils.jl")
 

--- a/src/bootstrap.jl
+++ b/src/bootstrap.jl
@@ -1,23 +1,50 @@
-function Bootstrap.bootstrap(statistic,
-                             data::Tuple{<:AbstractMatrix{<:Real},AbstractVector{<:Integer}},
-                             sampling::ConsistentSampling)
-    bootstrap(statistic, Random.GLOBAL_RNG, data, sampling)
+struct ConsistentSampling <: BootstrapSampling
+    nrun::Int
 end
 
 """
-    bootstrap(statistic[, rng::AbstractRNG = Random.GLOBAL_RNG], data,
-              sampling::ConsistentSampling)
+    bootstrap(statistic, data, sampling::ConsistentSampling[;
+              rng::AbstractRNG = Random.GLOBAL_RNG])
 
-Obtain non-parametric bootstrap sample of `statistic` from the `data` set of predictions and
-corresponding labels using consistency resampling, i.e., resampling of the labels, with
-random number generator `rng.`
+Obtain non-parametric bootstrap samples of `statistic` from the `data` set of predictions
+and corresponding labels using consistency resampling, i.e., resampling of the labels.
+
+Optionally you can specify a random number generator `rng` that is used for resampling
+the data.
 """
-function Bootstrap.bootstrap(statistic, rng::AbstractRNG,
+function Bootstrap.bootstrap(statistic,
                              data::Tuple{<:AbstractMatrix{<:Real},<:AbstractVector{<:Integer}},
-                             sampling::ConsistentSampling)
+                             sampling::ConsistentSampling;
+                             rng::AbstractRNG = Random.GLOBAL_RNG)
     # check arguments
     predictions, labels = data
-    nsamples = size(predictions, 2)
+    nclasses, nsamples = size(predictions)
+    nsamples == length(labels) ||
+        throw(DimensionMismatch("number of predictions and labels must be equal"))
+
+    # use same heuristic as StatsBase to decide whether to sample predictions
+    # directly or to build an alias table
+    # TODO: needs proper benchmarking
+    if nsamples < 40
+        bootstrap_direct(statistic, data, sampling; rng = rng)
+    else
+        t = nsamples < 500 ? 64 : 32
+        if nclasses < t
+            bootstrap_direct(statistic, data, sampling; rng = rng)
+        else
+            bootstrap_alias(statistic, data, sampling; rng = rng)
+        end
+    end
+end
+
+# sample labels directly (without alias table)
+function bootstrap_direct(statistic,
+                          data::Tuple{<:AbstractMatrix{<:Real},<:AbstractVector{<:Integer}},
+                          sampling::ConsistentSampling;
+                          rng::AbstractRNG = Random.GLOBAL_RNG)
+    # check arguments
+    predictions, labels = data
+    nclasses, nsamples = size(predictions)
     nsamples == length(labels) ||
         throw(DimensionMismatch("number of predictions and labels must be equal"))
 
@@ -25,13 +52,12 @@ function Bootstrap.bootstrap(statistic, rng::AbstractRNG,
     t0 = tx(statistic(data))
 
     # create caches
-    weights = [Weights(w) for w in eachcol(predictions)]
     resampled_predictions = similar(predictions)
     resampled_labels = similar(labels)
     resampled_data = (resampled_predictions, resampled_labels)
 
     # create sampler
-    sp = Random.Sampler(rng, Base.OneTo(nsamples))
+    sp = Random.RangeGenerator(Base.OneTo(nsamples))
 
     # create output
     m = nrun(sampling)
@@ -39,13 +65,23 @@ function Bootstrap.bootstrap(statistic, rng::AbstractRNG,
 
     # for each resampling step
     @inbounds for i in 1:m
-        # resample predictions and labels
+        # resample data
         for j in 1:nsamples
-            idx = rand(sp)
+            # resample predictions
+            idx = rand(rng, sp)
             for k in axes(predictions, 1)
                 resampled_predictions[k, j] = predictions[k, idx]
             end
-            resampled_labels[j] = sample(rng, weights[idx])
+
+            # resample labels
+            p = rand(rng)
+            cw = resampled_predictions[1, j]
+            label = 1
+            while cw < p && label < nclasses
+                label += 1
+                cw += resampled_predictions[label, j]
+            end
+            resampled_labels[j] = label
         end
 
         # evaluate statistic
@@ -54,5 +90,68 @@ function Bootstrap.bootstrap(statistic, rng::AbstractRNG,
         end
     end
 
-    return NonParametricBootstrapSample(t0, t1, statistic, data, sampling)
+    NonParametricBootstrapSample(t0, t1, statistic, data, sampling)
 end
+
+# sample labels with alias table
+function bootstrap_alias(statistic,
+                         data::Tuple{<:AbstractMatrix{<:Real},<:AbstractVector{<:Integer}},
+                         sampling::ConsistentSampling;
+                         rng::AbstractRNG = Random.GLOBAL_RNG)
+    # check arguments
+    predictions, labels = data
+    nclasses, nsamples = size(predictions)
+    nsamples == length(labels) ||
+        throw(DimensionMismatch("number of predictions and labels must be equal"))
+
+    # evaluate statistic
+    t0 = tx(statistic(data))
+
+    # create alias table
+    accept = [Vector{Float64}(undef, nclasses) for _ in 1:nsamples]
+    alias = [Vector{Int}(undef, nclasses) for _ in 1:nsamples]
+    @inbounds for i in axes(predictions, 2)
+        StatsBase.make_alias_table!(view(predictions, :, i), 1.0, accept[i], alias[i])
+    end
+
+    # create sampler of labels
+    splabels = Random.RangeGenerator(Base.OneTo(nclasses))
+
+    # create caches
+    resampled_predictions = similar(predictions)
+    resampled_labels = similar(labels)
+    resampled_data = (resampled_predictions, resampled_labels)
+
+    # create sampler
+    sp = Random.RangeGenerator(Base.OneTo(nsamples))
+
+    # create output
+    m = nrun(sampling)
+    t1 = zeros_tuple(typeof(t0), m)
+
+    # for each resampling step
+    @inbounds for i in 1:m
+        # resample data
+        for j in 1:nsamples
+            # resample predictions
+            idx = rand(rng, sp)
+            for k in axes(predictions, 1)
+                resampled_predictions[k, j] = predictions[k, idx]
+            end
+
+            # resample labels
+            l = rand(rng, splabels)
+            resampled_labels[j] = rand(rng) < accept[j][l] ? l : alias[j][l]
+        end
+
+        # evaluate statistic
+        for (j, t) in enumerate(tx(statistic(resampled_data)))
+            t1[j][i] = t
+        end
+    end
+
+    NonParametricBootstrapSample(t0, t1, statistic, data, sampling)
+end
+
+@deprecate bootstrap(statistic, predictions::AbstractMatrix{<:Real}, labels::AbstractVector{<:Integer}, sampling::ConsistentSampling) bootstrap(statistic, (predictions, labels), sampling)
+@deprecate bootstrap(statistic, rng::AbstractRNG, predictions::AbstractMatrix{<:Real}, labels::AbstractVector{<:Integer}, sampling::ConsistentSampling) bootstrap(statistic, (predictions, labels), sampling; rng = rng)

--- a/src/type.jl
+++ b/src/type.jl
@@ -1,3 +1,0 @@
-struct ConsistentSampling <: BootstrapSampling
-    nrun::Int
-end

--- a/test/simple.jl
+++ b/test/simple.jl
@@ -1,15 +1,19 @@
 using ConsistencyResampling, Bootstrap
 using Random
 
+using ConsistencyResampling: bootstrap_direct, bootstrap_alias
+
 Random.seed!(1234)
 
 @testset "Simple example" begin
     predictions = reshape([1, 0], 2, 1)
     labels = [2]
 
-    b = bootstrap(last, (predictions, labels), ConsistentSampling(20))
+    for f in (bootstrap, bootstrap_direct, bootstrap_alias)
+        b = bootstrap(last, (predictions, labels), ConsistentSampling(20))
 
-    @test data(b) == (predictions, labels)
-    @test original(b) == (2,)
-    @test straps(b) == (ones(Int, 20),)
+        @test data(b) == (predictions, labels)
+        @test original(b) == (2,)
+        @test straps(b) == (ones(Int, 20),)
+    end
 end


### PR DESCRIPTION
This PR adds some general performance improvements and the possibility to use an alias table for sampling.

A simple benchmark with
```julia
using ConsistencyResampling
using BenchmarkTools
using Statistics

f((x,y)) = var(y)
f(x, y) = var(y)

function testPR(nsamples, nclasses, nruns)
    predictions = rand(nclasses, nsamples)
    predictions ./= sum(predictions, dims=1)
    labels = rand(1:nclasses, nsamples)
    data = (predictions, labels)
    sampling = ConsistentSampling(nruns)

    @btime ConsistencyResampling.bootstrap_direct($stat, $data, $sampling)
    @btime ConsistencyResampling.bootstrap_alias($stat, $data, $sampling)
end

function testCurrent(nsamples, nclasses, nruns)
    predictions = rand(nclasses, nsamples)
    predictions ./= sum(predictions, dims=1)
    labels = rand(1:nclasses, nsamples)
    sampling = ConsistentSampling(nruns)

    @btime bootstrap($stat, $predictions, $labels, $sampling)
end
```
shows that on v0.1.0
```julia
julia> testCurrent(1000, 20, 1_000);
  69.119 ms (2013 allocations: 258.47 KiB)

julia> testCurrent(1000, 100, 1_000);
  146.124 ms (2013 allocations: 883.47 KiB)
```
whereas with this PR we get
```julia
julia> testPR(1000, 20, 1_000);
  46.452 ms (9 allocations: 172.31 KiB)
  43.486 ms (5011 allocations: 1.15 MiB)

julia> testPR(1000, 100, 1_000);
  104.369 ms (8 allocations: 797.30 KiB)
  78.247 ms (5010 allocations: 4.26 MiB)
```

This shows a clear improvement both for direct sampling and the newly added sampling using an alias table. Moreover, we see that regardless of the additional allocations sampling using an alias table outperforms the traditional approach if the number of classes is large. However, so far the heuristic when to switch to alias sampling is only copied from StatsBase. Further benchmarking should be performed to evaluate if this heuristic can be improved.